### PR TITLE
fix x-token header

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -36,12 +36,14 @@ const terminatingLink = split(
 );
 
 const authLink = new ApolloLink((operation, forward) => {
-  operation.setContext(({ headers = {} }) => ({
-    headers: {
-      ...headers,
-      'x-token': localStorage.getItem('token'),
-    },
-  }));
+  operation.setContext(({ headers = {}, localToken = localStorage.getItem('token') }) => {
+    if (localToken) {
+      headers['x-token'] = localToken;
+    }
+    return {
+      headers
+    }
+  });
 
   return forward(operation);
 });


### PR DESCRIPTION
https://github.com/rwieruch/fullstack-apollo-react-express-boilerplate-project/pull/14
unfortunately any value is getting a string in function setContext. 'false', 'null', 'undefined' etc.
https://github.com/rwieruch/fullstack-apollo-react-express-boilerplate-project/blob/master/server/src/index.js#L22 was always true

schöne grüße aus berlin. dein tut ist der hammer. lass mal ein bierchen trinken, wenn du bock hast.